### PR TITLE
Simplify the validation of templates

### DIFF
--- a/src/main/scala/com/ovoenergy/comms/templates/model/HandlebarsTemplate.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/model/HandlebarsTemplate.scala
@@ -9,5 +9,5 @@ import com.ovoenergy.comms.templates.ErrorsOr
   */
 case class HandlebarsTemplate(
     rawExpandedContent: String,
-    requiredData: ErrorsOr[RequiredTemplateData.obj]
+    requiredData: RequiredTemplateData.obj
 )

--- a/src/main/scala/com/ovoenergy/comms/templates/model/template/processed/email/EmailTemplate.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/model/template/processed/email/EmailTemplate.scala
@@ -26,9 +26,9 @@ case class EmailTemplate[M[_]: Applicative](
     import cats.instances.list._
     (subject |@| htmlBody |@| textBody.sequenceU) map {
       case (s, h, t) =>
-        val templates: List[HandlebarsTemplate]                     = List(Some(s), Some(h), t).flatten
-        val requiredDatas: ErrorsOr[List[RequiredTemplateData.obj]] = templates.map(_.requiredData).sequenceU
-        requiredDatas.andThen(RequiredTemplateData.combine)
+        val templates: List[HandlebarsTemplate]           = List(Some(s), Some(h), t).flatten
+        val requiredDatas: List[RequiredTemplateData.obj] = templates.map(_.requiredData)
+        RequiredTemplateData.combine(requiredDatas)
     }
   }
 }

--- a/src/main/scala/com/ovoenergy/comms/templates/model/template/processed/sms/SMSTemplate.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/model/template/processed/sms/SMSTemplate.scala
@@ -1,5 +1,6 @@
 package com.ovoenergy.comms.templates.model.template.processed.sms
 
+import cats.data.Validated.Valid
 import cats.{Applicative, Apply, Id}
 import com.ovoenergy.comms.templates._
 import com.ovoenergy.comms.templates.model.{HandlebarsTemplate, RequiredTemplateData}
@@ -12,6 +13,6 @@ case class SMSTemplate[M[_]: Applicative](textBody: M[HandlebarsTemplate]) {
     Apply[M].map(textBody)(SMSTemplate[Id])
 
   def requiredData: M[ErrorsOr[RequiredTemplateData.obj]] =
-    Apply[M].map(textBody)(_.requiredData)
+    Apply[M].map(textBody)(tb => Valid(tb.requiredData))
 
 }

--- a/src/test/scala/com/ovoenergy/comms/templates/TemplatesRepoSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/TemplatesRepoSpec.scala
@@ -73,7 +73,7 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
         templateFile match {
           case s if s == subject  => Invalid(NonEmptyList.of("Error parsing subject"))
           case b if b == htmlBody => Invalid(NonEmptyList.of("Error parsing htmlBody"))
-          case _                  => Valid(HandlebarsTemplate("Rendered template", Valid(obj(requiredData))))
+          case _                  => Valid(HandlebarsTemplate("Rendered template", obj(requiredData)))
         }
       }
     }
@@ -98,9 +98,9 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
       override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]] = None
     }
 
-    val parsedSubject  = HandlebarsTemplate("Rendered subject", Valid(obj(requiredData)))
-    val parsedHtmlBody = HandlebarsTemplate("Rendered html body", Valid(obj(requiredData)))
-    val parsedOther    = HandlebarsTemplate("Rendered other", Valid(obj(requiredData)))
+    val parsedSubject  = HandlebarsTemplate("Rendered subject", obj(requiredData))
+    val parsedHtmlBody = HandlebarsTemplate("Rendered html body", obj(requiredData))
+    val parsedOther    = HandlebarsTemplate("Rendered other", obj(requiredData))
     object Parser extends Parsing[HandlebarsTemplate] {
       override def parseTemplate(templateFile: TemplateFile): ErrorsOr[HandlebarsTemplate] = {
         templateFile match {
@@ -158,7 +158,7 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
             )))
     }
 
-    val parsedBody = HandlebarsTemplate("Rendered SMS body", Valid(obj(requiredData)))
+    val parsedBody = HandlebarsTemplate("Rendered SMS body", obj(requiredData))
     object Parser extends Parsing[HandlebarsTemplate] {
       override def parseTemplate(templateFile: TemplateFile): ErrorsOr[HandlebarsTemplate] = Valid(parsedBody)
     }

--- a/src/test/scala/com/ovoenergy/comms/templates/model/template/processed/CommTemplateSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/model/template/processed/CommTemplateSpec.scala
@@ -23,14 +23,14 @@ class CommTemplateSpec extends FlatSpec with Matchers with ValidatedMatchers {
     val template = CommTemplate[Id](
       email = Some(
         EmailTemplate[Id](
-          subject = HandlebarsTemplate("", Valid(reqData1)),
-          htmlBody = HandlebarsTemplate("", Valid(reqData2)),
-          textBody = Some(HandlebarsTemplate("", Valid(reqData3))),
+          subject = HandlebarsTemplate("", reqData1),
+          htmlBody = HandlebarsTemplate("", reqData2),
+          textBody = Some(HandlebarsTemplate("", reqData3)),
           sender = None
         )),
       sms = Some(
         SMSTemplate[Id](
-          textBody = HandlebarsTemplate("", Valid(reqData4))
+          textBody = HandlebarsTemplate("", reqData4)
         ))
     )
 
@@ -48,14 +48,14 @@ class CommTemplateSpec extends FlatSpec with Matchers with ValidatedMatchers {
     val template = CommTemplate[Id](
       email = Some(
         EmailTemplate[Id](
-          subject = HandlebarsTemplate("", Valid(reqData1)),
-          htmlBody = HandlebarsTemplate("", Valid(reqData2)),
-          textBody = Some(HandlebarsTemplate("", Valid(reqData3))),
+          subject = HandlebarsTemplate("", reqData1),
+          htmlBody = HandlebarsTemplate("", reqData2),
+          textBody = Some(HandlebarsTemplate("", reqData3)),
           sender = None
         )),
       sms = Some(
         SMSTemplate[Id](
-          textBody = HandlebarsTemplate("", Valid(conflictingReqData))
+          textBody = HandlebarsTemplate("", conflictingReqData)
         ))
     )
 

--- a/src/test/scala/com/ovoenergy/comms/templates/model/template/processed/email/EmailTemplateSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/model/template/processed/email/EmailTemplateSpec.scala
@@ -20,9 +20,9 @@ class EmailTemplateSpec extends FlatSpec with Matchers with ValidatedMatchers {
 
   it should "combine the required data from parts forming the template" in {
     val template = EmailTemplate[Id](
-      subject = HandlebarsTemplate("", Valid(reqData1)),
-      htmlBody = HandlebarsTemplate("", Valid(reqData2)),
-      textBody = Some(HandlebarsTemplate("", Valid(reqData3))),
+      subject = HandlebarsTemplate("", reqData1),
+      htmlBody = HandlebarsTemplate("", reqData2),
+      textBody = Some(HandlebarsTemplate("", reqData3)),
       sender = None
     )
 
@@ -36,8 +36,8 @@ class EmailTemplateSpec extends FlatSpec with Matchers with ValidatedMatchers {
 
   it should "combine the required data from parts forming the template no Text Body" in {
     val template = EmailTemplate[Id](
-      subject = HandlebarsTemplate("", Valid(reqData1)),
-      htmlBody = HandlebarsTemplate("", Valid(reqData2)),
+      subject = HandlebarsTemplate("", reqData1),
+      htmlBody = HandlebarsTemplate("", reqData2),
       textBody = None,
       sender = None
     )

--- a/src/test/scala/com/ovoenergy/comms/templates/parsing/handlebars/HandlebarsParsingSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/parsing/handlebars/HandlebarsParsingSpec.scala
@@ -5,14 +5,12 @@ import cats.scalatest.ValidatedMatchers
 import com.ovoenergy.comms.model.Channel.Email
 import com.ovoenergy.comms.model.{Channel, CommType}
 import com.ovoenergy.comms.model.CommType.Service
-import com.ovoenergy.comms.templates.model.variables.System
 import com.ovoenergy.comms.templates.model.FileFormat.Html
 import com.ovoenergy.comms.templates.model.{FileFormat, HandlebarsTemplate, RequiredTemplateData}
 import com.ovoenergy.comms.templates.model.template.files.TemplateFile
 import com.ovoenergy.comms.templates.parsing.handlebars.HandlebarsParsingProps.noOpPartialsRetriever
 import com.ovoenergy.comms.templates.retriever.PartialsRetriever
 import org.scalatest._
-import shapeless.HList
 import RequiredTemplateData._
 
 class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatchers {
@@ -685,8 +683,7 @@ class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatcher
       HandlebarsTemplate(
         rawExpandedContent =
           "A load of variables {{profile.firstName}} {{system.year}} {{recipient.emailAddress}} {{field1}} {{field2.sub1}} A partial {{partialField}} {{profile.lastName}}",
-        requiredData =
-          Valid(obj(Map("field1" -> string, "partialField" -> string, "field2" -> obj(Map("sub1" -> string)))))
+        requiredData = obj(Map("field1" -> string, "partialField" -> string, "field2" -> obj(Map("sub1" -> string))))
       ))
   }
 


### PR DESCRIPTION
If we can't parse a Handlebars template to extract the required data, or if we can parse it and we find that the required data is invalid, we treat the template as invalid.

In other words, `requiredData` has changed type from `ErrorsOr[RequiredTemplateData.obj]` to simply `RequiredTemplateData.obj`.

Supporting the case of "it's a valid template, sort of, but its required data is invalid" was not useful in practice and complicated the implementation.