### PR TITLE
Introduce concept of template manifest to project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ resolvers += Resolver.sonatypeRepo("snapshots") // for scalacheck-shapeless
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "1.0.0",
   "com.chuusai" %% "shapeless" % "2.3.2",
-  "com.ovoenergy" %% "comms-kafka-messages" % "1.40",
+    "com.ovoenergy" %% "comms-kafka-messages" % "1.66",
   "org.parboiled" %% "parboiled" % "2.1.3",
   "com.github.jknack" % "handlebars" % "4.0.6",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.57",
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.3.2",
   "com.github.ben-manes.caffeine" % "caffeine" % "2.4.0",
   "org.scalatest" %% "scalatest" % "3.0.1" % Test,
-  "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.5" % Test,
+  "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % Test,
   "com.ironcorelabs" %% "cats-scalatest" % "2.2.0" % Test
 )
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck,

--- a/src/main/scala/com/ovoenergy/comms/templates/TemplatesContext.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/TemplatesContext.scala
@@ -3,7 +3,7 @@ package com.ovoenergy.comms.templates
 import cats.Id
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
-import com.ovoenergy.comms.model.CommManifest
+import com.ovoenergy.comms.model.{CommManifest, TemplateManifest}
 import com.ovoenergy.comms.templates.cache.CachingStrategy
 import com.ovoenergy.comms.templates.model.HandlebarsTemplate
 import com.ovoenergy.comms.templates.model.template.processed.CommTemplate
@@ -24,7 +24,7 @@ object TemplatesContext {
     TemplatesContext(
       templatesRetriever = new TemplatesS3Retriever(s3Client),
       parser = new HandlebarsParsing(new PartialsS3Retriever(s3Client)),
-      cachingStrategy = CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]
+      cachingStrategy = CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]
     )
   }
 
@@ -38,7 +38,7 @@ object TemplatesContext {
     TemplatesContext(
       templatesRetriever = new TemplatesS3Retriever(s3Client),
       parser = new HandlebarsParsing(new PartialsS3Retriever(s3Client)),
-      cachingStrategy = CachingStrategy.caffeine[CommManifest, ErrorsOr[CommTemplate[Id]]](maximumSize = 100)
+      cachingStrategy = CachingStrategy.caffeine[TemplateManifest, ErrorsOr[CommTemplate[Id]]](maximumSize = 100)
     )
   }
 
@@ -46,7 +46,7 @@ object TemplatesContext {
     * A context that memoizes downloaded and parsed templates in a cache of your choice.
     */
   def customCachingContext(credentialsProvider: AWSCredentialsProvider,
-                           cachingStrategy: CachingStrategy[CommManifest, ErrorsOr[CommTemplate[Id]]],
+                           cachingStrategy: CachingStrategy[TemplateManifest, ErrorsOr[CommTemplate[Id]]],
                            bucket: String = "ovo-comms-templates"): TemplatesContext = {
     val s3Client = new AmazonS3ClientWrapper(new AmazonS3Client(credentialsProvider), bucket)
     TemplatesContext(
@@ -60,5 +60,5 @@ object TemplatesContext {
 case class TemplatesContext(
     templatesRetriever: TemplatesRetriever,
     parser: Parsing[HandlebarsTemplate],
-    cachingStrategy: CachingStrategy[CommManifest, ErrorsOr[CommTemplate[Id]]]
+    cachingStrategy: CachingStrategy[TemplateManifest, ErrorsOr[CommTemplate[Id]]]
 )

--- a/src/main/scala/com/ovoenergy/comms/templates/extensions/CommManifestExtensions.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/extensions/CommManifestExtensions.scala
@@ -1,0 +1,16 @@
+package com.ovoenergy.comms.templates.extensions
+
+import com.ovoenergy.comms.model.{CommManifest, TemplateManifest}
+import com.ovoenergy.comms.templates.util.Hash
+
+trait CommManifestExtensions {
+  implicit class CommManifestExtensions(commManifest: CommManifest) {
+
+    def toTemplateManifest: TemplateManifest = {
+      TemplateManifest(
+        Hash(commManifest.name),
+        commManifest.version
+      )
+    }
+  }
+}

--- a/src/main/scala/com/ovoenergy/comms/templates/model/template/files/TemplateFile.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/model/template/files/TemplateFile.scala
@@ -3,4 +3,4 @@ package com.ovoenergy.comms.templates.model.template.files
 import com.ovoenergy.comms.model.{Channel, CommType}
 import com.ovoenergy.comms.templates.model.FileFormat
 
-case class TemplateFile(commType: CommType, channel: Channel, format: FileFormat, content: String)
+case class TemplateFile(channel: Channel, format: FileFormat, content: String)

--- a/src/main/scala/com/ovoenergy/comms/templates/retriever/PartialsS3Retriever.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/retriever/PartialsS3Retriever.scala
@@ -6,10 +6,9 @@ import com.ovoenergy.comms.templates.s3.S3Client
 class PartialsS3Retriever(s3client: S3Client) extends PartialsRetriever {
 
   def getSharedPartial(referringFile: TemplateFile, partialName: String): Either[String, String] = {
-    val channel  = referringFile.channel.toString.toLowerCase
-    val commType = referringFile.commType.toString.toLowerCase
+    val channel = referringFile.channel.toString.toLowerCase
     val resource =
-      s"$commType/fragments/$channel/${referringFile.format.extension}/$partialName.${referringFile.format.extension}"
+      s"fragments/$channel/${referringFile.format.extension}/$partialName.${referringFile.format.extension}"
     s3client.getUTF8TextFileContent(resource) match {
       case Some(content) => Right(content)
       case None          => Left(s"Could not find shared partial: $partialName")

--- a/src/main/scala/com/ovoenergy/comms/templates/retriever/TemplatesRetriever.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/retriever/TemplatesRetriever.scala
@@ -1,6 +1,6 @@
 package com.ovoenergy.comms.templates.retriever
 
-import com.ovoenergy.comms.model.CommManifest
+import com.ovoenergy.comms.model.{CommManifest, TemplateManifest}
 import com.ovoenergy.comms.templates._
 import com.ovoenergy.comms.templates.model.template.files.email.EmailTemplateFiles
 import com.ovoenergy.comms.templates.model.template.files.print.PrintTemplateFiles
@@ -8,10 +8,10 @@ import com.ovoenergy.comms.templates.model.template.files.sms.SMSTemplateFiles
 
 trait TemplatesRetriever {
 
-  def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]]
+  def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]]
 
-  def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]
+  def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]
 
-  def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]]
+  def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]]
 
 }

--- a/src/main/scala/com/ovoenergy/comms/templates/retriever/TemplatesS3Retriever.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/retriever/TemplatesS3Retriever.scala
@@ -33,27 +33,27 @@ class TemplatesS3Retriever(s3Client: S3Client) extends TemplatesRetriever {
     }
   }
 
-  def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = {
-    if (s3Client.listFiles(templatePrefix(Email, commManifest)).isEmpty) {
-      log.debug(s"No email template found for $commManifest")
+  def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = {
+    if (s3Client.listFiles(templatePrefix(Email, templateManifest)).isEmpty) {
+      log.debug(s"No email template found for $templateManifest")
       None
     } else {
       val subject: ErrorsOr[TemplateFile] = {
-        val option = s3File(Filenames.Email.Subject, Email, commManifest)
-          .map(TemplateFile(commManifest.commType, Email, FileFormat.Text, _))
+        val option = s3File(Filenames.Email.Subject, Email, templateManifest)
+          .map(TemplateFile(Email, FileFormat.Text, _))
         Validated.fromOption(option, ifNone = NonEmptyList.of("Subject file not found on S3"))
       }
 
       val htmlBody: ErrorsOr[TemplateFile] = {
-        val option = s3File(Filenames.Email.HtmlBody, Email, commManifest)
-          .map(TemplateFile(commManifest.commType, Email, FileFormat.Html, _))
+        val option = s3File(Filenames.Email.HtmlBody, Email, templateManifest)
+          .map(TemplateFile(Email, FileFormat.Html, _))
         Validated.fromOption(option, ifNone = NonEmptyList.of("HTML body file not found on S3"))
       }
 
-      val textBody: Option[TemplateFile] = s3File(Filenames.Email.TextBody, Email, commManifest)
-        .map(TemplateFile(commManifest.commType, Email, FileFormat.Text, _))
+      val textBody: Option[TemplateFile] = s3File(Filenames.Email.TextBody, Email, templateManifest)
+        .map(TemplateFile(Email, FileFormat.Text, _))
 
-      val customSender: Option[String] = s3File(Filenames.Email.Sender, Email, commManifest)
+      val customSender: Option[String] = s3File(Filenames.Email.Sender, Email, templateManifest)
 
       Some(
         (subject, htmlBody).mapN {
@@ -64,15 +64,15 @@ class TemplatesS3Retriever(s3Client: S3Client) extends TemplatesRetriever {
     }
   }
 
-  override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = {
-    if (s3Client.listFiles(templatePrefix(Print, commManifest)).isEmpty) {
-      log.debug(s"No print template found for $commManifest")
+  override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = {
+    if (s3Client.listFiles(templatePrefix(Print, templateManifest)).isEmpty) {
+      log.debug(s"No print template found for $templateManifest")
       None
     } else {
 
       val body: ErrorsOr[TemplateFile] = {
-        val option = s3File(Filenames.Print.body, Print, commManifest)
-          .map(TemplateFile(commManifest.commType, Print, FileFormat.Html, _))
+        val option = s3File(Filenames.Print.body, Print, templateManifest)
+          .map(TemplateFile(Print, FileFormat.Html, _))
         Validated.fromOption(option, ifNone = NonEmptyList.of("HTML body file not found on S3"))
       }
 
@@ -80,27 +80,27 @@ class TemplatesS3Retriever(s3Client: S3Client) extends TemplatesRetriever {
     }
   }
 
-  override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]] = {
-    if (s3Client.listFiles(templatePrefix(SMS, commManifest)).isEmpty) {
-      log.debug(s"No SMS template found for $commManifest")
+  override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]] = {
+    if (s3Client.listFiles(templatePrefix(SMS, templateManifest)).isEmpty) {
+      log.debug(s"No SMS template found for $templateManifest")
       None
     } else {
       val textBody: ErrorsOr[TemplateFile] = {
-        val option = s3File(Filenames.SMS.TextBody, SMS, commManifest)
-          .map(TemplateFile(commManifest.commType, SMS, FileFormat.Text, _))
+        val option = s3File(Filenames.SMS.TextBody, SMS, templateManifest)
+          .map(TemplateFile(SMS, FileFormat.Text, _))
         Validated.fromOption(option, ifNone = NonEmptyList.of("Text body file not found on S3"))
       }
       Some(textBody.map(SMSTemplateFiles))
     }
   }
 
-  private def s3File(filename: String, channel: Channel, commManifest: CommManifest): Option[String] =
-    s3Client.getUTF8TextFileContent(templateFileKey(channel, commManifest, filename))
+  private def s3File(filename: String, channel: Channel, templateManifest: TemplateManifest): Option[String] =
+    s3Client.getUTF8TextFileContent(templateFileKey(channel, templateManifest, filename))
 
-  private def templatePrefix(channel: Channel, commManifest: CommManifest): String =
-    s"${commManifest.commType.toString.toLowerCase}/${commManifest.name}/${commManifest.version}/${channel.toString.toLowerCase}"
+  private def templatePrefix(channel: Channel, templateManifest: TemplateManifest): String =
+    s"${templateManifest.id}/${templateManifest.version}/${channel.toString.toLowerCase}"
 
-  private def templateFileKey(channel: Channel, commManifest: CommManifest, filename: String): String =
-    s"${templatePrefix(channel, commManifest)}/$filename"
+  private def templateFileKey(channel: Channel, templateManifest: TemplateManifest, filename: String): String =
+    s"${templatePrefix(channel, templateManifest)}/$filename"
 
 }

--- a/src/main/scala/com/ovoenergy/comms/templates/util/Hash.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/util/Hash.scala
@@ -1,0 +1,21 @@
+package com.ovoenergy.comms.templates.util
+
+import java.security.MessageDigest
+
+object Hash {
+
+  /*
+      Used for hashing legacy Comm names to retrieve the new Template ID.
+
+      **Note**
+      lowercase only due to s3 buckets being case sensitive, and URLS not.
+
+   */
+  def apply(str: String): String = {
+    val hash = MessageDigest
+      .getInstance("MD5")
+      .digest(str.getBytes)
+
+    new String(hash).toLowerCase
+  }
+}

--- a/src/main/scala/com/ovoenergy/comms/templates/util/Hash.scala
+++ b/src/main/scala/com/ovoenergy/comms/templates/util/Hash.scala
@@ -1,6 +1,7 @@
 package com.ovoenergy.comms.templates.util
 
 import java.security.MessageDigest
+import java.util.Base64
 
 object Hash {
 
@@ -16,6 +17,6 @@ object Hash {
       .getInstance("MD5")
       .digest(str.getBytes)
 
-    new String(hash).toLowerCase
+    Base64.getEncoder.withoutPadding().encodeToString(hash).toLowerCase
   }
 }

--- a/src/test/scala/com/ovoenergy/comms/templates/TemplatesRepoSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/TemplatesRepoSpec.scala
@@ -7,6 +7,7 @@ import cats.scalatest.ValidatedMatchers
 import com.ovoenergy.comms.model._
 import com.ovoenergy.comms.templates
 import com.ovoenergy.comms.templates.cache.CachingStrategy
+import com.ovoenergy.comms.templates.extensions.CommManifestExtensions
 import com.ovoenergy.comms.templates.model.RequiredTemplateData.{obj, string}
 import com.ovoenergy.comms.templates.model.{FileFormat, HandlebarsTemplate, RequiredTemplateData}
 import com.ovoenergy.comms.templates.model.template.files.TemplateFile
@@ -21,7 +22,7 @@ import com.ovoenergy.comms.templates.parsing.Parsing
 import com.ovoenergy.comms.templates.retriever.TemplatesRetriever
 import org.scalatest.{FlatSpec, Matchers}
 
-class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
+class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers with CommManifestExtensions {
 
   object NoOpParsing extends Parsing[HandlebarsTemplate] {
     override def parseTemplate(templateFile: TemplateFile): ErrorsOr[HandlebarsTemplate] = {
@@ -29,7 +30,8 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
     }
   }
 
-  val commManifest = CommManifest(Service, "some-template", "1.0")
+  val commManifest     = CommManifest(Service, "some-template", "1.0")
+  val templateManifest = commManifest.toTemplateManifest
   val requiredData: Map[String, RequiredTemplateData] = Map(
     "field1" -> string,
     "field2" -> string
@@ -39,36 +41,36 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
 
   it should "return an Invalid if there are no templates for any channels" in {
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                NoOpParsing,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) should
       haveInvalid("Template has no channels defined")
   }
 
   it should "handle errors retrieving email template" in {
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] =
         Some(Invalid(NonEmptyList.of("Some error retrieving email template")))
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                NoOpParsing,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) should
       haveInvalid("Some error retrieving email template")
   }
 
   it should "handle errors parsing email template" in {
-    val subject  = TemplateFile(commManifest.commType, Email, FileFormat.Text, "The Subject")
-    val htmlBody = TemplateFile(commManifest.commType, Email, FileFormat.Html, "The Html Body")
+    val subject  = TemplateFile(Email, FileFormat.Text, "The Subject")
+    val htmlBody = TemplateFile(Email, FileFormat.Html, "The Html Body")
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] =
         Some(
           Valid(
             EmailTemplateFiles(
@@ -77,8 +79,8 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
               textBody = None,
               sender = None
             )))
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
 
     object Parser extends Parsing[HandlebarsTemplate] {
@@ -93,16 +95,16 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
     TemplatesRepo.getTemplate(
       TemplatesContext(MockTemplatesRetriever,
                        Parser,
-                       CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                       CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
       commManifest) should (haveInvalid("Error parsing subject") and haveInvalid("Error parsing htmlBody"))
   }
 
   it should "process valid email template" in {
-    val subject  = TemplateFile(commManifest.commType, Email, FileFormat.Text, "The Subject")
-    val htmlBody = TemplateFile(commManifest.commType, Email, FileFormat.Html, "The Html Body")
-    val other    = TemplateFile(commManifest.commType, Email, FileFormat.Text, "Other")
+    val subject  = TemplateFile(Email, FileFormat.Text, "The Subject")
+    val htmlBody = TemplateFile(Email, FileFormat.Html, "The Html Body")
+    val other    = TemplateFile(Email, FileFormat.Text, "Other")
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] =
         Some(
           Valid(
             EmailTemplateFiles(
@@ -111,8 +113,8 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
               textBody = Some(other),
               sender = None
             )))
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
 
     val parsedSubject  = HandlebarsTemplate("Rendered subject", obj(requiredData))
@@ -135,37 +137,38 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
     )
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                Parser,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) shouldBe Valid(exp)
   }
 
   it should "handle errors retrieving SMS template" in {
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]] =
         Some(Invalid(NonEmptyList.of("Some error retrieving SMS template")))
 
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
 
     val result: ErrorsOr[CommTemplate[Id]] =
-      TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
-                                                 NoOpParsing,
-                                                 CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
-                                commManifest)
+      TemplatesRepo.getTemplate(
+        TemplatesContext(MockTemplatesRetriever,
+                         NoOpParsing,
+                         CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
+        commManifest)
     result should haveInvalid("Some error retrieving SMS template")
   }
 
   it should "handle errors parsing SMS template" in {
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]] =
         Some(
           Valid(
             SMSTemplateFiles(
-              textBody = TemplateFile(commManifest.commType, SMS, FileFormat.Text, "the SMS body")
+              textBody = TemplateFile(SMS, FileFormat.Text, "the SMS body")
             )))
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
 
     object Parser extends Parsing[HandlebarsTemplate] {
@@ -174,21 +177,21 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
     }
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                Parser,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) should
       haveInvalid("Parsing error")
   }
 
   it should "process valid SMS template" in {
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]] =
         Some(
           Valid(
             SMSTemplateFiles(
-              textBody = TemplateFile(commManifest.commType, SMS, FileFormat.Text, "the SMS body")
+              textBody = TemplateFile(SMS, FileFormat.Text, "the SMS body")
             )))
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] = None
     }
 
     val parsedBody = HandlebarsTemplate("Rendered SMS body", obj(requiredData))
@@ -203,19 +206,19 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
     )
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                Parser,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) shouldBe Valid(exp)
   }
 
   it should "process valid print template" in {
-    val header = TemplateFile(commManifest.commType, Print, FileFormat.Text, "The Header")
-    val body   = TemplateFile(commManifest.commType, Print, FileFormat.Html, "The Html Body")
-    val footer = TemplateFile(commManifest.commType, Print, FileFormat.Text, "Footer")
+    val header = TemplateFile(Print, FileFormat.Text, "The Header")
+    val body   = TemplateFile(Print, FileFormat.Html, "The Html Body")
+    val footer = TemplateFile(Print, FileFormat.Text, "Footer")
 
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] =
         Some(
           Valid(
             PrintTemplateFiles(body)
@@ -246,31 +249,84 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
 
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                Parser,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) shouldBe Valid(exp)
+  }
+
+  it should "return the same result for both template as comm manifest " in {
+    val header = TemplateFile(Print, FileFormat.Text, "The Header")
+    val body   = TemplateFile(Print, FileFormat.Html, "The Html Body")
+    val footer = TemplateFile(Print, FileFormat.Text, "Footer")
+
+    object MockTemplatesRetriever extends TemplatesRetriever {
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] =
+        Some(
+          Valid(
+            PrintTemplateFiles(body)
+          )
+        )
+    }
+
+    val parsedHeader   = HandlebarsTemplate("Rendered header", obj(requiredData))
+    val parsedHtmlBody = HandlebarsTemplate("Rendered html body", obj(requiredData))
+    val parsedFooter   = HandlebarsTemplate("Rendered footer", obj(requiredData))
+
+    object Parser extends Parsing[HandlebarsTemplate] {
+      override def parseTemplate(templateFile: TemplateFile): ErrorsOr[HandlebarsTemplate] = {
+        templateFile match {
+          case h if h == header => Valid(parsedHeader)
+          case b if b == body   => Valid(parsedHtmlBody)
+          case f if f == footer => Valid(parsedFooter)
+          case _                => fail("Unexpected template file parsed")
+        }
+      }
+    }
+
+    val exp = CommTemplate[Id](
+      email = None,
+      sms = None,
+      print = Some(PrintTemplate[Id](parsedHtmlBody))
+    )
+
+    val cmResult = TemplatesRepo.getTemplate(
+      TemplatesContext(MockTemplatesRetriever,
+                       Parser,
+                       CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
+      commManifest)
+
+    val tmResult = TemplatesRepo.getTemplate(
+      TemplatesContext(MockTemplatesRetriever,
+                       Parser,
+                       CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
+      templateManifest)
+
+    cmResult shouldBe Valid(exp)
+    cmResult shouldBe tmResult
   }
 
   it should "handle errors retrieving print template" in {
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] =
         Some(Invalid(NonEmptyList.of("Some error retrieving print template")))
     }
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                NoOpParsing,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) should
       haveInvalid("Some error retrieving print template")
   }
 
   it should "handle errors parsing print template" in {
-    val body = TemplateFile(commManifest.commType, Print, FileFormat.Html, "The Html Body")
+    val body = TemplateFile(Print, FileFormat.Html, "The Html Body")
 
     object MockTemplatesRetriever extends TemplatesRetriever {
-      override def getEmailTemplate(commManifest: CommManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
-      override def getSMSTemplate(commManifest: CommManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
-      override def getPrintTemplate(commManifest: CommManifest): Option[ErrorsOr[PrintTemplateFiles]] =
+      override def getEmailTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[EmailTemplateFiles]] = None
+      override def getSMSTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[SMSTemplateFiles]]     = None
+      override def getPrintTemplate(templateManifest: TemplateManifest): Option[ErrorsOr[PrintTemplateFiles]] =
         Some(
           Valid(
             PrintTemplateFiles(body)
@@ -288,7 +344,7 @@ class TemplatesRepoSpec extends FlatSpec with Matchers with ValidatedMatchers {
     }
     TemplatesRepo.getTemplate(TemplatesContext(MockTemplatesRetriever,
                                                Parser,
-                                               CachingStrategy.noCache[CommManifest, ErrorsOr[CommTemplate[Id]]]),
+                                               CachingStrategy.noCache[TemplateManifest, ErrorsOr[CommTemplate[Id]]]),
                               commManifest) should (haveInvalid("Error parsing htmlBody"))
   }
 

--- a/src/test/scala/com/ovoenergy/comms/templates/parsing/handlebars/HandlebarsParsingSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/parsing/handlebars/HandlebarsParsingSpec.scala
@@ -13,8 +13,8 @@ import RequiredTemplateData._
 
 class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatchers {
 
-  val emailTemplateFile = TemplateFile(Service, Email, FileFormat.Text, "")
-  val smsTemplateFile   = TemplateFile(Service, SMS, FileFormat.Text, "")
+  val emailTemplateFile = TemplateFile(Email, FileFormat.Text, "")
+  val smsTemplateFile   = TemplateFile(SMS, FileFormat.Text, "")
 
   behavior of "#buildRequiredTemplateData"
 
@@ -531,8 +531,7 @@ class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatcher
       }
     }
     val templateFile =
-      TemplateFile(Service,
-                   Email,
+      TemplateFile(Email,
                    Html,
                    "This template contains a partial: {{> a.partial  }}. And a partial at the end: {{>final.partial}}")
     new HandlebarsParsing(partialsRetriever).resolvePartials(templateFile) shouldBe Right(
@@ -545,12 +544,12 @@ class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatcher
         Left("An error")
       }
     }
-    val templateFile = TemplateFile(Service, Email, Html, "This template contains a partial: {{> a.partial}}")
+    val templateFile = TemplateFile(Email, Html, "This template contains a partial: {{> a.partial}}")
     new HandlebarsParsing(partialsRetriever).resolvePartials(templateFile) shouldBe Left("An error")
   }
 
   it should "ignore partials with only single curly braces" in {
-    val templateFile = TemplateFile(Service, Email, Html, "This template contains a dodgy partial: {> a.partial}")
+    val templateFile = TemplateFile(Email, Html, "This template contains a dodgy partial: {> a.partial}")
     new HandlebarsParsing(noOpPartialsRetriever).resolvePartials(templateFile) shouldBe Right(
       "This template contains a dodgy partial: {> a.partial}")
   }
@@ -691,7 +690,7 @@ class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatcher
         responses.getOrElse(partialName, Left("Non mapped response"))
       }
     }
-    val templateFile = TemplateFile(Service, Email, FileFormat.Text, templateContent)
+    val templateFile = TemplateFile(Email, FileFormat.Text, templateContent)
     new HandlebarsParsing(partialsRetriever).parseTemplate(templateFile) should beValid(
       HandlebarsTemplate(
         rawExpandedContent =
@@ -714,7 +713,7 @@ class HandlebarsParsingSpec extends FlatSpec with Matchers with ValidatedMatcher
         responses.getOrElse(partialName, Left("Non mapped response"))
       }
     }
-    val templateFile = TemplateFile(Service, Email, FileFormat.Text, templateContent)
+    val templateFile = TemplateFile(Email, FileFormat.Text, templateContent)
     new HandlebarsParsing(partialsRetriever).parseTemplate(templateFile) should haveInvalid(
       "Encountered excessive recursion when expanding partials"
     )

--- a/src/test/scala/com/ovoenergy/comms/templates/retriever/PartialsS3RetrieverSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/retriever/PartialsS3RetrieverSpec.scala
@@ -15,17 +15,17 @@ class PartialsS3RetrieverSpec extends FlatSpec with Matchers with EitherValues {
 
   val s3client = s3(
     contents = Map(
-      "service/fragments/email/html/header.html" -> "the HTML header",
-      "service/fragments/email/html/thing.html"  -> "another HTML fragment",
-      "service/fragments/email/txt/header.txt"   -> "the text header"
+      "fragments/email/html/header.html" -> "the HTML header",
+      "fragments/email/html/thing.html"  -> "another HTML fragment",
+      "fragments/email/txt/header.txt"   -> "the text header"
     ),
     files = Map(
-      "service/fragments/email/html" -> Seq(
-        "service/fragments/email/html/header.html",
-        "service/fragments/email/html/thing.html"
+      "fragments/email/html" -> Seq(
+        "fragments/email/html/header.html",
+        "fragments/email/html/thing.html"
       ),
-      "service/fragments/email/txt" -> Seq(
-        "service/fragments/email/txt/header.txt"
+      "fragments/email/txt" -> Seq(
+        "fragments/email/txt/header.txt"
       )
     )
   )
@@ -35,18 +35,16 @@ class PartialsS3RetrieverSpec extends FlatSpec with Matchers with EitherValues {
   behavior of "Partials Repo for emails"
 
   it should "get html partials" in {
-    testObj.getSharedPartial(TemplateFile(Service, Email, FileFormat.Html, ""), "header") shouldBe Right(
-      "the HTML header")
+    testObj.getSharedPartial(TemplateFile(Email, FileFormat.Html, ""), "header") shouldBe Right("the HTML header")
   }
 
   it should "get text partials" in {
-    testObj.getSharedPartial(TemplateFile(Service, Email, FileFormat.Text, ""), "header") shouldBe Right(
-      "the text header")
+    testObj.getSharedPartial(TemplateFile(Email, FileFormat.Text, ""), "header") shouldBe Right("the text header")
   }
 
   it should "fail if partial not present" in {
     testObj
-      .getSharedPartial(TemplateFile(Service, Email, FileFormat.Text, ""), "whatevs")
+      .getSharedPartial(TemplateFile(Email, FileFormat.Text, ""), "whatevs")
       .left
       .value should include("Could not find shared partial")
   }

--- a/src/test/scala/com/ovoenergy/comms/templates/util/HashSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/templates/util/HashSpec.scala
@@ -1,0 +1,20 @@
+package com.ovoenergy.comms.templates.util
+
+import org.scalacheck.Prop.forAllNoShrink
+import org.scalacheck.{Arbitrary, Gen, Properties}
+
+object HashSpec extends Properties("Hash") {
+
+  implicit val arbInt = Arbitrary(Gen.posNum[Int])
+
+  /** Taken from scalacheck, due to old transitive dependency from scalacheck-shapeless*/
+  implicit val nonEmptyArbAsciiString = Arbitrary(Gen.alphaNumStr)
+
+  property("is referentially transparent for any string") = forAllNoShrink { (str: String, int: Int) =>
+    val hashValues = (1 to int).foldLeft(List.empty[String]) { (acc, elem) =>
+      acc :+ Hash(str)
+    }
+
+    hashValues.distinct.length == 1
+  }
+}


### PR DESCRIPTION
For this feature to be used within an application, the S3 bucket structure needs to go from:

CommType -> CommName -> Version -> Channel

to:

TemplateId -> Version -> Channel

Where TemplateId for legacy templates needs to be an MD5 hash of the comm name, using the Hash utility function included in this PR
